### PR TITLE
chore: bump Go to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM golang:1.26.6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/davidkarlsen/flyway-operator
 
-go 1.26.1
+go 1.26.6
 
 require (
 	github.com/caitlinelfring/go-env-default v1.1.0


### PR DESCRIPTION
Repo was on Go 1.26.1; latest release is 1.26.6.

- `go.mod`: `go 1.26.1` → `go 1.26.6`
- `Dockerfile`: builder image `golang:1.26` → `golang:1.26.6` (explicit patch pin)

CI workflows use `go-version-file: go.mod`, so they pick this up automatically.

`go build ./...` and `go vet ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)